### PR TITLE
Adding a settings object to hold any settings for the plugin.

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -1,5 +1,9 @@
 (function ($) {
-
+    $.expandingTextarea = $.extend({
+        autoInitialize: true,
+        initialSelector: "textarea.expanding"
+    }, $.expandingTextarea || {});
+    
     var cloneCSSProperties = [
         'lineHeight', 'textDecoration', 'letterSpacing',
         'fontSize', 'fontFamily', 'fontStyle', 
@@ -68,10 +72,10 @@
         return this;
     };
 
-    $.fn.expandingTextarea.initialSelector = "textarea.expanding";
-
     $(function () {
-        $($.fn.expandingTextarea.initialSelector).expandingTextarea();
+        if ($.expandingTextarea.autoInitialize) {
+            $($.expandingTextarea.initialSelector).expandingTextarea();
+        }
     });
 
 })(jQuery);


### PR DESCRIPTION
Initially has `autoInitialize` and `initialSelector` settings.

I changed it from `$.fn.textareaExpanding` to just `$.textareaExpanding` instead. That seems to match more of what I have seen in other plugins, but if you want we can change it back to the `$.fn` instead.
