### PR TITLE
Adding support for CommonJS and AMD registration.

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -1,8 +1,5 @@
 (function(factory) {
-    if (typeof exports === 'object') {
-        // Node/CommonJS
-        factory(require('jquery'));
-    } else if (typeof define === 'function' && define.amd) {
+    if (typeof define === 'function' && define.amd) {
         // AMD Registration
         define([ 'jquery' ], factory);
     } else {


### PR DESCRIPTION
Allows for registration as a CommonJS module or registration with an AMD, such as RequireJS.

Falls back to the browser global jQuery object.
