### PR TITLE
Added Word-Break to List of Cloned CSS

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -23,7 +23,7 @@
         'fontSize', 'fontFamily', 'fontStyle', 
         'fontWeight', 'textTransform', 'textAlign', 
         'direction', 'wordSpacing', 'fontSizeAdjust', 
-        'wordWrap', 
+        'wordWrap', 'word-break',
         'borderLeftWidth', 'borderRightWidth',
         'borderTopWidth','borderBottomWidth',
         'paddingLeft', 'paddingRight',


### PR DESCRIPTION
Added word-break to list of cloned css properties since leaving it off causes issues if pre tags are styled differently.  This became apparent because Twitter Bootstrap uses word-break: break-all for all pre tags.

Also, I've never done a pull request before so if I screwed this up let me know.  Thanks.

Jonathan
