### PR TITLE
Fixes word-wrap not working in IE and removes an unnecessary DOM-access

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -23,7 +23,7 @@
         'fontSize', 'fontFamily', 'fontStyle', 
         'fontWeight', 'textTransform', 'textAlign', 
         'direction', 'wordSpacing', 'fontSizeAdjust', 
-        'wordWrap', 'word-break',
+        'word-break',
         'borderLeftWidth', 'borderRightWidth',
         'borderTopWidth','borderBottomWidth',
         'paddingLeft', 'paddingRight',
@@ -81,6 +81,7 @@
 
             var container = $("<div class='expandingText'></div>").css(containerCSS);
             var pre = $("<pre class='textareaClone'><div></div></pre>").css(preCSS);
+            pre.find('div').css('wordWrap', 'break-word');
 
             textarea.wrap(container);
             textarea.after(pre);

--- a/expanding.js
+++ b/expanding.js
@@ -78,12 +78,12 @@
         
         this.filter("textarea").not(".expanding-init").addClass("expanding-init").each(function() {
             var textarea = $(this);
-            
-            textarea.wrap("<div class='expandingText'></div>");
-            textarea.after("<pre class='textareaClone'><div></div></pre>");
-            
-            var container = textarea.parent().css(containerCSS);
-            var pre = container.find("pre").css(preCSS);
+
+            var container = $("<div class='expandingText'></div>").css(containerCSS);
+            var pre = $("<pre class='textareaClone'><div></div></pre>").css(preCSS);
+
+            textarea.wrap(container);
+            textarea.after(pre);
             
             // Store the original styles in case of destroying.
             textarea.data('expanding-styles', textarea.attr('style'));

--- a/expanding.js
+++ b/expanding.js
@@ -1,4 +1,6 @@
 // Expanding Textareas
+// https://github.com/adrianschmidt/ExpandingTextareas
+// Forked from:
 // https://github.com/bgrins/ExpandingTextareas
 
 (function(factory) {
@@ -17,12 +19,12 @@
             resize: function() { }
         }
     }, $.expandingTextarea || {});
-    
+
     var cloneCSSProperties = [
         'lineHeight', 'textDecoration', 'letterSpacing',
-        'fontSize', 'fontFamily', 'fontStyle', 
-        'fontWeight', 'textTransform', 'textAlign', 
-        'direction', 'wordSpacing', 'fontSizeAdjust', 
+        'fontSize', 'fontFamily', 'fontStyle',
+        'fontWeight', 'textTransform', 'textAlign',
+        'direction', 'wordSpacing', 'fontSizeAdjust',
         'word-break',
         'borderLeftWidth', 'borderRightWidth',
         'borderTopWidth','borderBottomWidth',
@@ -32,50 +34,51 @@
         'marginTop','marginBottom',
         'boxSizing', 'webkitBoxSizing', 'mozBoxSizing', 'msBoxSizing'
     ];
-    
+
     var textareaCSS = {
         position: "absolute",
         height: "100%",
-        resize: "none"
+        resize: "none",
+        overflow: "hidden"
     };
-    
+
     var preCSS = {
         visibility: "hidden",
         border: "0 solid",
-        whiteSpace: "pre-wrap" 
+        whiteSpace: "pre-wrap"
     };
-    
+
     var containerCSS = {
         position: "relative"
     };
-    
+
     function resize() {
         $(this).closest('.expandingText').find("div").text(this.value + ' ');
         $(this).trigger("resize.expanding");
     }
-    
+
     $.fn.expandingTextarea = function(o) {
-        
+
         var opts = $.extend({ }, $.expandingTextarea.opts, o);
-        
+
         if (o === "resize") {
             return this.trigger("input.expanding");
         }
-        
+
         if (o === "destroy") {
             this.filter(".expanding-init").each(function() {
                 var textarea = $(this).removeClass('expanding-init');
                 var container = textarea.closest('.expandingText');
-                
+
                 container.before(textarea).remove();
                 textarea
                     .attr('style', textarea.data('expanding-styles') || '')
                     .removeData('expanding-styles');
             });
-            
+
             return this;
         }
-        
+
         this.filter("textarea").not(".expanding-init").addClass("expanding-init").each(function() {
             var textarea = $(this);
 
@@ -85,35 +88,35 @@
 
             textarea.wrap(container);
             textarea.after(pre);
-            
+
             // Store the original styles in case of destroying.
             textarea.data('expanding-styles', textarea.attr('style'));
             textarea.css(textareaCSS);
-            
+
             $.each(cloneCSSProperties, function(i, p) {
                 var val = textarea.css(p);
-                
+
                 // Only set if different to prevent overriding percentage css values.
                 if (pre.css(p) !== val) {
                     pre.css(p, val);
                 }
             });
-            
+
             textarea.bind("input.expanding propertychange.expanding keyup.expanding", resize);
             resize.apply(this);
-            
+
             if (opts.resize) {
                 textarea.bind("resize.expanding", opts.resize);
             }
         });
-        
+
         return this;
     };
-    
+
     $(function () {
         if ($.expandingTextarea.autoInitialize) {
             $($.expandingTextarea.initialSelector).expandingTextarea();
         }
     });
-    
+
 }));


### PR DESCRIPTION
I hope these changes will be useful to others. I have tested them in the application I'm currently working on, using IE9, Chrome and Firefox.

I have not tested extensively using different scenarios.

The word-wrap property will no longer be overrideable after this update.