### PR TITLE
Add val function

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -68,7 +68,7 @@
             }
             else if (arguments.length === 2) {
                 $(this).val(arguments[1]);
-                return $(this).trigger("input-expanding")
+                return $(this).trigger("input.expanding")
             }
             else {
                 throw Error("'val' expects zero or one additional arguments")


### PR DESCRIPTION
Setting the value of an expanding textarea fails to trigger any of the usual re-size callbacks.  I added a `val` function to expanding textarea so that you can set it and have it resize itself after it was set.

Usage:

```
$('textarea').expandingTextarea();
$('textarea').expandingTextarea('val', 'A long\n\nmultiline\n\n\nstring');
```

Afterward you will notice that the textarea has expanded to show the full `val`.
