### PR TITLE
set height of container to match textarea

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -99,7 +99,7 @@
                 }
             });
             
-            container.css({"min-height": textarea.height()});
+            container.css({"min-height": textarea.outerHeight(true)});
             
             textarea.bind("input.expanding propertychange.expanding keyup.expanding", resize);
             resize.apply(this);


### PR DESCRIPTION
Because the textarea is position:absolute, the height of the container collapses to match the pre element. This fixes that.
