### PR TITLE
Listen to `change` event.

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -20,9 +20,9 @@
     
     var cloneCSSProperties = [
         'lineHeight', 'textDecoration', 'letterSpacing',
-        'fontSize', 'fontFamily', 'fontStyle', 
-        'fontWeight', 'textTransform', 'textAlign', 
-        'direction', 'wordSpacing', 'fontSizeAdjust', 
+        'fontSize', 'fontFamily', 'fontStyle',
+        'fontWeight', 'textTransform', 'textAlign',
+        'direction', 'wordSpacing', 'fontSizeAdjust',
         'wordWrap', 'word-break',
         'borderLeftWidth', 'borderRightWidth',
         'borderTopWidth','borderBottomWidth',
@@ -99,7 +99,7 @@
                 }
             });
             
-            textarea.bind("input.expanding propertychange.expanding keyup.expanding", resize);
+            textarea.bind("input.expanding propertychange.expanding keyup.expanding change.expanding", resize);
             resize.apply(this);
             
             if (opts.resize) {


### PR DESCRIPTION
**Doesn't completely solve #30** because `.val()` doesn't trigger the `change` event, but does provide the workaround:

```
$('#myTextarea').val('Some new content').change();
```

DEMO: http://jsfiddle.net/CnRhG/
