### PR TITLE
Max height to expand

### DIFF
--- a/expanding.js
+++ b/expanding.js
@@ -50,9 +50,9 @@
 
     function resize() {
         var maxHeight = parseInt($(this).css('max-height'));
-		if(maxHeight > 0 && parseInt($(this).closest('.expandingText').find("pre").height()) >= maxHeight) {
-			return;
-		}
+        if(maxHeight > 0 && parseInt($(this).closest('.expandingText').find("pre").height()) >= maxHeight) {
+            return;
+        }
 		$(this).closest('.expandingText').find("div").text(this.value.replace(/\r\n/g, "\n") + ' ');
         $(this).trigger("resize.expanding");
     }


### PR DESCRIPTION
It is very often needed to set maximum height to expand textarea. very clean way is simply set `max-height` css property to textarea. no need for additional parameters.

This change will stop adding text to hidden `pre/div` if we have reached the height limit
