### PR TITLE
Include ExpandingTextareas in plugins.jquery.com

### DIFF
--- a/expanding.jquery.json
+++ b/expanding.jquery.json
@@ -1,0 +1,20 @@
+{
+  "name":"ExpandingTextareas",
+  "version":"0.1.2",
+  "title":"jQuery plugin for elegant expanding textareas",
+  "author":{
+    "name":"bgrins",
+    "url":"http://github.com/bgrins"
+  },
+  "homepage":"http://github.com/bgrins/ExpandingTextareas/",
+  "demo":"http://bgrins.github.io/ExpandingTextareas/",
+  "licenses":[
+    {
+      "type":"MIT",
+      "url":"https://github.com/bgrins/ExpandingTextareas/blob/master/LICENSE"
+    }
+  ],
+  "dependencies":{
+    "jquery":"*"
+  }
+}


### PR DESCRIPTION
This is pretty easy and might make this plugin more discoverable.

Essentially, you'd need to connect the repo to the jQuery Plugin Registry via webhook, publish a [valid manifest file](http://plugins.jquery.com/docs/package-manifest/) and then bump the version to trigger a registry update.

Full instructions here: http://plugins.jquery.com/docs/publish/
