### PR TITLE
Test auto-initialization

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
       }
     },
     qunit: {
-      all: ['test/index.html']
+      all: ['test/index.html', 'test/document_ready.html']
     }
   });
 

--- a/test/document_ready.html
+++ b/test/document_ready.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Expanding Textarea Document Ready Test</title>
+  <link rel="stylesheet" href="../libs/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture">
+    <textarea class="expanding">My textarea</textarea>
+  </div>
+  <script src="../libs/jquery-1.11.0.js"></script>
+  <script src="../libs/qunit.js"></script>
+
+  <script src="../expanding.js"></script>
+  <script>
+  test('textareas with the `expanding` class are initialized on document ready', 1, function () {
+    ok($('.expanding').expanding('active'));
+  });
+  </script>
+</body>
+</html>

--- a/test/expanding_test.js
+++ b/test/expanding_test.js
@@ -13,6 +13,18 @@ test('`data(\'expanding\')` returns an Expanding instance', 1, function () {
   ok(this.$textarea.data('expanding') instanceof $.fn.expanding.Constructor);
 });
 
+// ============
+// = Defaults =
+// ============
+
+test('Auto-initialize option', 1, function () {
+  ok($.expanding.autoInitialize);
+});
+
+test('Initial selector option', 1, function () {
+  equal($.expanding.initialSelector, 'textarea.expanding');
+});
+
 // ========
 // = Init =
 // ========


### PR DESCRIPTION
Adds a new file to test for document ready behaviour.
Tests `$.expanding` options

(See #55 for discussion)