### PR TITLE
Allow jQuery options to accept 'update'

### DIFF
--- a/src/expanding.jquery.js
+++ b/src/expanding.jquery.js
@@ -38,6 +38,9 @@ import Expanding from './expanding'
           case 'refresh':
             instance.refresh()
             return
+          case 'update':
+            instance.update()
+            return
           default:
             return
         }


### PR DESCRIPTION
This allows you to easily update textareas from a jQuery selector.

Useful if submitting via ajax and then clearing the content.